### PR TITLE
Add OpenSRE to job list

### DIFF
--- a/repos.csv
+++ b/repos.csv
@@ -146,3 +146,4 @@ dapr/dapr,Diagrid,https://www.diagrid.io,https://www.diagrid.io/careers,"distrib
 argoproj/argo-cd,Akuity,https://www.akuity.io,https://www.akuity.io/careers/,"gitops, kubernetes, continuous-deployment, argocd, devops",Go,Declarative continuous deployment for Kubernetes.
 openedx/edx-platform,OpenCraft,https://opencraft.com/,https://opencraft.com/jobs/,"edx, education",Python,"The Open edX LMS & Studio, powering education sites around the world!"
 penpot/penpot,Penpot,https://penpot.app,https://penpot.app/careers,"design, clojure, ui, clojurescript, prototyping, ux-experience, ux-design",Clojure,Penpot: The open-source design tool for design and code collaboration
+Tracer-Cloud/opensre,OpenSRE,https://opensre.com,https://jobs.ashbyhq.com/tracer,"ai-sre, alerting, observability, incident-management, root-cause-analysis, site-reliability-engineering, sre",Python,Build your own AI SRE agents. The open source toolkit for the AI era.


### PR DESCRIPTION
## Summary

- Adds [OpenSRE](https://github.com/Tracer-Cloud/opensre) to the open-source jobs list
- OpenSRE is an open-source Python toolkit for building AI SRE agents, covering observability, alerting, incident management, and root cause analysis
- Careers page: https://jobs.ashbyhq.com/tracer

## Changes

Added a new row to `repos.csv` with:

| Field | Value |
|-------|-------|
| Repository | `Tracer-Cloud/opensre` |
| Company | OpenSRE |
| Website | https://opensre.com |
| Careers | https://jobs.ashbyhq.com/tracer |
| Language | Python |
| Tags | ai-sre, alerting, observability, incident-management, root-cause-analysis, site-reliability-engineering, sre |